### PR TITLE
fixup! fixup! Update shipment_planning_maxoptra/wizard/shipment_maxop…

### DIFF
--- a/shipment_planning_maxoptra/models/res_partner.py
+++ b/shipment_planning_maxoptra/models/res_partner.py
@@ -10,8 +10,8 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     maxoptra_driver_name = fields.Char(
-        string="Driver External ID",
-        help="External ID of Driver in Maxoptra, used to target the right "
+        string="Driver External Name",
+        help="External name of Driver in Maxoptra, used to target the right "
         "partner to set on Batch pickings after import.",
     )
 

--- a/shipment_planning_maxoptra/readme/DESCRIPTION.rst
+++ b/shipment_planning_maxoptra/readme/DESCRIPTION.rst
@@ -6,3 +6,22 @@ generated on Maxoptra to create batch picking per vehicle to do the deliveries.
 
 The wizard also also to reschedule picking operation if the warehouse
 Outgoing Shipments are using "2 steps".
+
+Time selected in the wizard will be stating point for scheduling pickings in delivery
+locations
+
+* Wizard should handle pick planning in serial(actual implementation) or in parallel.
+  Example:
+  If we have to schedule following pickings and the start time is 6.00 AM with 15 mins duration:
+
+    PICK1 (Shelf 1 > Output)
+    PICK2 (Shelf 1 > Output)
+    PICK3 (Shelf 2 > Output)
+    PICK4 (Shelf 2 > Output)
+
+  With parallel planning:
+
+      PICK1: 6.00 AM -> BATCH1
+      PICK2: 6.15 AM -> BATCH1
+      PICK3: 6.00 AM -> BATCH2
+      PICK4: 6.15 AM -> BATCH2

--- a/shipment_planning_maxoptra/readme/ROADMAP.rst
+++ b/shipment_planning_maxoptra/readme/ROADMAP.rst
@@ -3,25 +3,3 @@
 * Column names in CSV generated on Maxoptra can differ from the columns used
   by the wizard. (e.g. Rescheduling of Delivery Operations is based on
   "Scheduled arrival time" which must be present in CSV)
-* Wizard should handle pick planning in serial(actual implementation) or in parallel.
-  Example:
-  If we have to schedule following pickings and the start time is 6.00 AM with 15 mins duration:
-
-    PICK1 (Shelf 1 > Output)
-    PICK2 (Shelf 1 > Output)
-    PICK3 (Shelf 2 > Output)
-    PICK4 (Shelf 2 > Output)
-
-  We could either have a serial planning (actual implementation):
-
-      PICK1: 6.00 AM
-      PICK2: 6.15 AM
-      PICK3: 6.30 AM
-      PICK4: 6.45 AM
-
-  Or a parallel planning:
-
-      PICK1: 6.00 AM
-      PICK2: 6.15 AM
-      PICK3: 6.00 AM
-      PICK4: 6.15 AM

--- a/shipment_planning_maxoptra/tests/test_maxoptra.py
+++ b/shipment_planning_maxoptra/tests/test_maxoptra.py
@@ -343,3 +343,4 @@ class TestMaxoptra(SavepointCase):
             self._get_previous_pickings(self.delivery_gemini).scheduled_date,
             pick_start_time + relativedelta(minutes=15),
         )
+        # TODO scheduled_date doesn't have impact on scheduled_date on batch

--- a/shipment_planning_maxoptra/views/shipment_planning.xml
+++ b/shipment_planning_maxoptra/views/shipment_planning.xml
@@ -5,6 +5,13 @@
         <field name="model">shipment.planning</field>
         <field name="inherit_id" ref="shipment_planning.shipment_planning_view_form" />
         <field name="arch" type="xml">
+
+            <xpath expr="//notebook" position="inside">
+                <page string="Related batches" name="batch">
+                    <field name="batch_picking_ids" readonly="1" />
+                </page>
+            </xpath>
+
             <xpath expr="//group[@name='info2']" position="inside">
                 <field name="maxoptra_planning" />
                 <field

--- a/shipment_planning_maxoptra/wizard/shipment_maxoptra_schedule_import.py
+++ b/shipment_planning_maxoptra/wizard/shipment_maxoptra_schedule_import.py
@@ -138,7 +138,11 @@ class ShipmentMaxoptraScheduleImport(models.TransientModel):
                 picks = self.env["stock.picking"].browse(
                     [pick.id for pick in pick_list]
                 )
-                new_batch = batch_obj.create({"picking_ids": [(6, 0, picks.ids)]})
+                new_batch = batch_obj.create({
+                    "vehicle_id": batch_picking.vehicle_id.id,
+                    "driver_id": batch_picking.driver_id.id,
+                    "picking_ids": [(6, 0, picks.ids)],
+                })
                 new_batch_picking_ids.append(new_batch.id)
                 if start_datetime and operation_duration:
                     picks = self.sort_on_outgoing_date(picks, reverse_order)


### PR DESCRIPTION
before this commit, we got the same number of batches for the pick step as the outgoing step, mainly because driver grouping 
this is wrong, as internal batch shouldn't follow this logic and all internal picks can be assigned to one batch 